### PR TITLE
Register mock tokens in json database

### DIFF
--- a/helpers/contracts-deployments.ts
+++ b/helpers/contracts-deployments.ts
@@ -387,6 +387,7 @@ export const deployAllMockTokens = async (verify?: boolean) => {
       [tokenSymbol, tokenSymbol, configData ? configData.reserveDecimals : decimals],
       verify
     );
+    await registerContractInJsonDb(tokenSymbol.toUpperCase(), tokens[tokenSymbol]);
   }
   return tokens;
 };


### PR DESCRIPTION
Allows all steps of the `aave:dev` task to run successfully