### PR TITLE
Fix compilation issue at BaseUniswapAdapter.sol 

### DIFF
--- a/contracts/adapters/BaseUniswapAdapter.sol
+++ b/contracts/adapters/BaseUniswapAdapter.sol
@@ -349,13 +349,15 @@ abstract contract BaseUniswapAdapter is FlashLoanReceiverBase, IBaseUniswapAdapt
 
     if (reserveIn == reserveOut) {
       uint256 reserveDecimals = _getDecimals(reserveIn);
+      address[] memory path = new address[](1);
+      path[0] = reserveIn;
       return
         AmountCalc(
           finalAmountIn,
           finalAmountIn.mul(10**18).div(amountIn),
           _calcUsdValue(reserveIn, amountIn, reserveDecimals),
           _calcUsdValue(reserveIn, finalAmountIn, reserveDecimals),
-          [reserveIn]
+          path
         );
     }
 
@@ -437,13 +439,15 @@ abstract contract BaseUniswapAdapter is FlashLoanReceiverBase, IBaseUniswapAdapt
       // Add flash loan fee
       uint256 amountIn = amountOut.add(amountOut.mul(FLASHLOAN_PREMIUM_TOTAL).div(10000));
       uint256 reserveDecimals = _getDecimals(reserveIn);
+      address[] memory path = new address[](1);
+      path[0] = reserveIn;
       return
         AmountCalc(
           amountIn,
           amountOut.mul(10**18).div(amountIn),
           _calcUsdValue(reserveIn, amountIn, reserveDecimals),
           _calcUsdValue(reserveIn, amountOut, reserveDecimals),
-          [reserveIn]
+          path
         );
     }
 


### PR DESCRIPTION
Fix compilation issue at BaseUniswapAdapter.sol  due invalid argument in function call.

Currently running hardhat compile causes the next error at master branch:
```
contracts/adapters/BaseUniswapAdapter.sol:358:11: TypeError: Invalid type for argument in function call. Invalid implicit conversion from address[1] memory to address[] memory requested.
          [reserveIn]
          ^---------^

contracts/adapters/BaseUniswapAdapter.sol:446:11: TypeError: Invalid type for argument in function call. Invalid implicit conversion from address[1] memory to address[] memory requested.
          [reserveIn]
          ^---------^

Error HH600: Compilation failed
```
