### PR TITLE
fix: removed unused hardhat console import

### DIFF
--- a/contracts/protocol/lendingpool/DefaultReserveInterestRateStrategy.sol
+++ b/contracts/protocol/lendingpool/DefaultReserveInterestRateStrategy.sol
@@ -8,7 +8,6 @@ import {PercentageMath} from '../libraries/math/PercentageMath.sol';
 import {ILendingPoolAddressesProvider} from '../../interfaces/ILendingPoolAddressesProvider.sol';
 import {ILendingRateOracle} from '../../interfaces/ILendingRateOracle.sol';
 import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
-import 'hardhat/console.sol';
 
 /**
  * @title DefaultReserveInterestRateStrategy contract


### PR DESCRIPTION
Removes the unused hardhat console import from `DefaultReserveInterestRateStrategy.sol`.