### PR TITLE
Show Build status badge at README.md

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,4 @@
-name: Aave Actions
+name: Build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+![Build pass](https://github.com/AAVE/protocol-v2/actions/workflows/node.js.yml/badge.svg)
 ```
         .///.                .///.     //.            .//  `/////////////-
        `++:++`              .++:++`    :++`          `++:  `++:......---.`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-![Build pass](https://github.com/AAVE/protocol-v2/actions/workflows/node.js.yml/badge.svg)
+[![Build pass](https://github.com/AAVE/protocol-v2/actions/workflows/node.js.yml/badge.svg)](https://github.com/aave/protocol-v2/actions/workflows/node.js.yml)
 ```
         .///.                .///.     //.            .//  `/////////////-
        `++:++`              .++:++`    :++`          `++:  `++:......---.`


### PR DESCRIPTION
-  Add a SVG Badge to README.md that shows the current Github Action status of the `master` branch, hosted by Github, following the [Github documentation](https://docs.github.com/es/actions/managing-workflow-runs/adding-a-workflow-status-badge)
- Rename the current Github Actions CI name to "Build".