### PR TITLE
resolve confusing comment in IAaveIncentivesController.sol

### DIFF
--- a/contracts/interfaces/IAaveIncentivesController.sol
+++ b/contracts/interfaces/IAaveIncentivesController.sol
@@ -65,7 +65,7 @@ interface IAaveIncentivesController {
   ) external;
 
   /**
-   * @dev Returns the total of rewards of an user, already accrued + not yet accrued
+   * @dev Returns the total accrued rewards of an user
    * @param user The address of the user
    * @return The rewards
    **/


### PR DESCRIPTION
I found the natspec comments regarding the `getRewardsBalance` function confusing. I don't think there's such thing as not yet accrued rewards, so i removed that. If there is, I would suggest explaining what not-yet-accrued rewards might be