### PR TITLE
Deployment Bug Fix - Added argument to task

### DIFF
--- a/tasks/deployments/add-market-to-registry.ts
+++ b/tasks/deployments/add-market-to-registry.ts
@@ -40,7 +40,7 @@ task('add-market-to-registry', 'Adds address provider to registry')
     ) {
       console.log('- Deploying a new Address Providers Registry:');
 
-      await DRE.run('full:deploy-address-provider-registry', { verify });
+      await DRE.run('full:deploy-address-provider-registry', { verify, pool });
 
       providerRegistryAddress = (await getLendingPoolAddressesProviderRegistry()).address;
       providerRegistryOwner = await (await getFirstSigner()).getAddress();


### PR DESCRIPTION
The `pool` argument is required to execute the task `full:deploy-address-provider-registry` 

If not passed, the following error will be thrown by hardhat - `HH306: Missing task argument pool`