### PR TITLE
ci: remove kovan step due doesnt support tx type 2

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -40,10 +40,6 @@ jobs:
         run: npm run amm:fork:main
         env:
           ALCHEMY_KEY: ${{ secrets.ALCHEMY_KEY }}
-      - name: Aave deployment at Kovan fork
-        run: npm run aave:fork:kovan
-        env:
-          ALCHEMY_KEY: ${{ secrets.ALCHEMY_KEY }}
       # - name: Coverage
       #   run: npm run coverage
       # - uses: codecov/codecov-action@v1


### PR DESCRIPTION
Remove the Kovan fork deployment at Github Actions due Kovan doesnt support transactions of type 2.