### PR TITLE
Update ATokensAndRatesHelper.sol

### DIFF
--- a/contracts/deployments/ATokensAndRatesHelper.sol
+++ b/contracts/deployments/ATokensAndRatesHelper.sol
@@ -27,12 +27,12 @@ contract ATokensAndRatesHelper is Ownable {
 
   struct ConfigureReserveInput {
     address asset;
+    bool stableBorrowingEnabled;
+    bool borrowingEnabled;
     uint256 baseLTV;
     uint256 liquidationThreshold;
     uint256 liquidationBonus;
     uint256 reserveFactor;
-    bool stableBorrowingEnabled;
-    bool borrowingEnabled;
   }
 
   constructor(
@@ -46,7 +46,7 @@ contract ATokensAndRatesHelper is Ownable {
   }
 
   function initDeployment(InitDeploymentInput[] calldata inputParams) external onlyOwner {
-    for (uint256 i = 0; i < inputParams.length; i++) {
+    for (uint256 i; i < inputParams.length; ++i) {
       emit deployedContracts(
         address(new AToken()),
         address(
@@ -66,7 +66,7 @@ contract ATokensAndRatesHelper is Ownable {
 
   function configureReserves(ConfigureReserveInput[] calldata inputParams) external onlyOwner {
     LendingPoolConfigurator configurator = LendingPoolConfigurator(poolConfigurator);
-    for (uint256 i = 0; i < inputParams.length; i++) {
+    for (uint256 i; i < inputParams.length; ++i) {
       configurator.configureReserveAsCollateral(
         inputParams[i].asset,
         inputParams[i].baseLTV,


### PR DESCRIPTION
2 Types of changes made:

1st -> Struct Packing - This makes clear that structs uses as less slots as possible in order to save gas, the combination of `address bool bool` now uses 1 slot rather than 2 in the earlier implementation
Refer this -> https://dev.to/javier123454321/solidity-gas-optimizations-pt-3-packing-structs-23f4

2nd -> For loop improvement - `uint256 i = 0` changed to `uint256 i`, usually all unsigned integers have a default value as 0
And, `i++` to `++i`, This is really a good gas enhancement unless this change messes up with the code's logic which I feel it don't
Refer this -> https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#for-loops-improvement 